### PR TITLE
add the missing .. code block javascript directive

### DIFF
--- a/docs/source/template_input.rst
+++ b/docs/source/template_input.rst
@@ -60,6 +60,9 @@ Metacat version
   }
 
 Minerva version:
+^^^^^^^^^^^^^^^
+
+.. code-block:: javascript
 
 {
     "checksums": {


### PR DESCRIPTION
Was missing a .. code block javascript directive so the minerva section wasn't formatting correctly.

now added. 